### PR TITLE
Fix consumer so that it can work with `any` input, rather than `map[string]any`

### DIFF
--- a/mwtail/main.go
+++ b/mwtail/main.go
@@ -112,7 +112,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Create a consumer that reads generic nested dictionaries from `topicName`.
+	// Create a consumer that reads generic events from `topicName`.
 	consumer, err := client.NewConsumer(
 		profile,
 		client.DeclareWebhookTopic[any](topicName),

--- a/mwtail/main.go
+++ b/mwtail/main.go
@@ -115,18 +115,15 @@ func main() {
 	// Create a consumer that reads generic nested dictionaries from `topicName`.
 	consumer, err := client.NewConsumer(
 		profile,
-		client.DeclareWebhookTopic[map[string]any](topicName),
+		client.DeclareWebhookTopic[any](topicName),
 	)
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Loop endlessly (or until a network error) reading nested dictionaries and dumping them to stdout. In a real consumer,
-	// this is where you'd place your custom handling code. Replace `map[string]any` with a type that has `json` struct tags
-	// and you'll get automatical deserialization of event payloads into an instance of that type. When your handler returns
-	// an error, consumer.Consume() will cleanly shut down and then return that error.
-	err = consumer.Consume(context.Background(), func(ctx context.Context, event *client.Webhook[map[string]any]) error {
+	// Loop endlessly (or until a network error) reading input events and dumping them to stdout.
+	err = consumer.Consume(context.Background(), func(ctx context.Context, event *client.Webhook[any]) error {
 		return render(log.Writer(), event)
 	})
 


### PR DESCRIPTION
So it turns out that not everybody sends a JSON object as their webhook payload. Some send a JSON array instead.

Since `mwtail` has to be simpatico with all webhook providers, it cannot assume it's going to receive `map[string]any`s.